### PR TITLE
Add C# reverse proxy and port forward sample

### DIFF
--- a/csharp-proxy/Agent/Agent.csproj
+++ b/csharp-proxy/Agent/Agent.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/csharp-proxy/Agent/Program.cs
+++ b/csharp-proxy/Agent/Program.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        string host = args.Length > 0 ? args[0] : "localhost";
+        var client = new TcpClient();
+        await client.ConnectAsync(host, 9000);
+        var stream = client.GetStream();
+        var reader = new StreamReader(stream, Encoding.UTF8);
+        var writer = new StreamWriter(stream, new UTF8Encoding(false)) { AutoFlush = true };
+        await writer.WriteLineAsync("AUTH secret");
+        var agent = new Agent(reader, writer);
+        await agent.Run();
+    }
+}
+
+class Agent
+{
+    readonly StreamReader reader;
+    readonly StreamWriter writer;
+    readonly HttpClient http = new HttpClient();
+    ConcurrentDictionary<string, TcpClient> forwards = new();
+
+    public Agent(StreamReader r, StreamWriter w)
+    {
+        reader = r;
+        writer = w;
+    }
+
+    public async Task Run()
+    {
+        string? line;
+        while ((line = await reader.ReadLineAsync()) != null)
+        {
+            var doc = JsonDocument.Parse(line);
+            var type = doc.RootElement.GetProperty("Type").GetString();
+            var id = doc.RootElement.GetProperty("Id").GetString()!;
+            if (type == "HttpRequest")
+            {
+                var method = doc.RootElement.GetProperty("Method").GetString()!;
+                var url = doc.RootElement.GetProperty("Url").GetString()!;
+                var headers = doc.RootElement.GetProperty("Headers").EnumerateObject().ToDictionary(p => p.Name, p => p.Value.GetString()!);
+                var bodyBase64 = doc.RootElement.GetProperty("Body").GetString();
+                var body = Encoding.UTF8.GetString(Convert.FromBase64String(bodyBase64 ?? ""));
+                var req = new HttpRequestMessage(new HttpMethod(method), url);
+                foreach (var h in headers)
+                    req.Headers.TryAddWithoutValidation(h.Key, h.Value);
+                if (body.Length > 0)
+                    req.Content = new StringContent(body, Encoding.UTF8);
+                var resp = await http.SendAsync(req);
+                var respHeaders = resp.Headers.Concat(resp.Content.Headers)
+                    .ToDictionary(h => h.Key, h => string.Join(",", h.Value));
+                var respBody = await resp.Content.ReadAsStringAsync();
+                await SendAsync(new
+                {
+                    Type = "HttpResponse",
+                    Id = id,
+                    StatusCode = (int)resp.StatusCode,
+                    Headers = respHeaders,
+                    Body = Convert.ToBase64String(Encoding.UTF8.GetBytes(respBody))
+                });
+            }
+            else if (type == "PortOpen")
+            {
+                int port = doc.RootElement.GetProperty("Port").GetInt32();
+                var local = new TcpClient();
+                await local.ConnectAsync("127.0.0.1", port);
+                forwards[id] = local;
+                _ = PumpLocalToServer(id, local);
+            }
+            else if (type == "PortData")
+            {
+                if (forwards.TryGetValue(id, out var local))
+                {
+                    var data = Convert.FromBase64String(doc.RootElement.GetProperty("Data").GetString()!);
+                    await local.GetStream().WriteAsync(data, 0, data.Length);
+                }
+            }
+            else if (type == "PortClose")
+            {
+                if (forwards.TryRemove(id, out var local))
+                {
+                    local.Close();
+                }
+            }
+        }
+    }
+
+    async Task PumpLocalToServer(string id, TcpClient local)
+    {
+        var stream = local.GetStream();
+        var buf = new byte[4096];
+        try
+        {
+            while (true)
+            {
+                int n = await stream.ReadAsync(buf, 0, buf.Length);
+                if (n <= 0) break;
+                await SendAsync(new { Type = "PortData", Id = id, Data = Convert.ToBase64String(buf, 0, n) });
+            }
+        }
+        finally
+        {
+            await SendAsync(new { Type = "PortClose", Id = id });
+            local.Close();
+        }
+    }
+
+    Task SendAsync(object obj)
+    {
+        string json = JsonSerializer.Serialize(obj);
+        return writer.WriteLineAsync(json);
+    }
+}

--- a/csharp-proxy/README.md
+++ b/csharp-proxy/README.md
@@ -1,0 +1,34 @@
+# C# Reverse Proxy
+
+This prototype demonstrates a minimal reverse proxy and port forwarding system inspired by the v2ray-core architecture.
+
+* **Agent (A)** – runs inside the private network and keeps a persistent TCP connection to the server.
+* **Server (S)** – accepts the agent connection and exposes:
+  * an HTTP endpoint for authenticated clients to issue arbitrary HTTP requests through the agent;
+  * a TCP port forward (similar to frp) allowing remote SSH access.
+
+The code focuses on network proxying and removes the other features found in v2ray. Messages are JSON lines exchanged over the persistent connection.
+
+### Building
+A .NET SDK is required:
+```bash
+dotnet build
+```
+
+### Running
+1. Start the server:
+   ```bash
+   dotnet run --project Server/Server.csproj
+   ```
+2. Start the agent on the machine that owns the network connection:
+   ```bash
+   dotnet run --project Agent/Agent.csproj -- <server_host>
+   ```
+3. Issue HTTP requests through the server:
+   ```bash
+   curl -H 'X-Forward-Token: secret' -H 'X-Target-Url: http://example.com' \
+        -H 'X-Forward-Method: GET' http://<server_host>:8080/proxy
+   ```
+4. Connect to the forwarded SSH port (`1212`) on the server to reach the agent's local port `22`.
+
+This is a simplified educational example and lacks production-ready security and error handling.

--- a/csharp-proxy/Server/Program.cs
+++ b/csharp-proxy/Server/Program.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+class Program
+{
+    static ConcurrentDictionary<string, AgentConnection> agents = new();
+
+    static async Task Main(string[] args)
+    {
+        _ = AcceptAgents();
+        _ = StartHttp();
+        _ = StartPortForward();
+        Console.WriteLine("Server running. Press Enter to exit.");
+        Console.ReadLine();
+    }
+
+    static async Task AcceptAgents()
+    {
+        var listener = new TcpListener(IPAddress.Any, 9000);
+        listener.Start();
+        while (true)
+        {
+            var client = await listener.AcceptTcpClientAsync();
+            _ = HandleAgent(client);
+        }
+    }
+
+    static async Task HandleAgent(TcpClient client)
+    {
+        var stream = client.GetStream();
+        var reader = new StreamReader(stream, Encoding.UTF8);
+        var writer = new StreamWriter(stream, new UTF8Encoding(false)) { AutoFlush = true };
+        var line = await reader.ReadLineAsync();
+        if (line == null || !line.StartsWith("AUTH "))
+        {
+            client.Close();
+            return;
+        }
+        var token = line.Substring(5).Trim();
+        var agent = new AgentConnection(token, client, reader, writer);
+        agents[token] = agent;
+        Console.WriteLine($"Agent {token} connected");
+        await agent.ProcessMessages();
+        agents.TryRemove(token, out _);
+        Console.WriteLine($"Agent {token} disconnected");
+    }
+
+    static async Task StartHttp()
+    {
+        var listener = new HttpListener();
+        listener.Prefixes.Add("http://*:8080/");
+        listener.Start();
+        while (true)
+        {
+            var ctx = await listener.GetContextAsync();
+            _ = Task.Run(() => HandleHttp(ctx));
+        }
+    }
+
+    static async Task HandleHttp(HttpListenerContext ctx)
+    {
+        var token = ctx.Request.Headers["X-Forward-Token"];
+        var target = ctx.Request.Headers["X-Target-Url"];
+        var method = ctx.Request.Headers["X-Forward-Method"] ?? ctx.Request.HttpMethod;
+        if (token == null || target == null || !agents.TryGetValue(token, out var agent))
+        {
+            ctx.Response.StatusCode = 502;
+            ctx.Response.Close();
+            return;
+        }
+        string body = await new StreamReader(ctx.Request.InputStream).ReadToEndAsync();
+        var id = Guid.NewGuid().ToString();
+        var req = new
+        {
+            Type = "HttpRequest",
+            Id = id,
+            Method = method,
+            Url = target,
+            Headers = ctx.Request.Headers.AllKeys.ToDictionary(k => k!, k => ctx.Request.Headers[k]! ),
+            Body = Convert.ToBase64String(Encoding.UTF8.GetBytes(body))
+        };
+        var tcs = new TaskCompletionSource<HttpResponse>();
+        agent.Pending[id] = tcs;
+        await agent.SendAsync(req);
+        var resp = await tcs.Task;
+        ctx.Response.StatusCode = resp.StatusCode;
+        foreach (var h in resp.Headers)
+            ctx.Response.Headers[h.Key] = h.Value;
+        var respBody = Encoding.UTF8.GetBytes(resp.Body);
+        await ctx.Response.OutputStream.WriteAsync(respBody, 0, respBody.Length);
+        ctx.Response.Close();
+    }
+
+    static async Task StartPortForward()
+    {
+        var listener = new TcpListener(IPAddress.Any, 1212);
+        listener.Start();
+        while (true)
+        {
+            var client = await listener.AcceptTcpClientAsync();
+            _ = HandleForward(client);
+        }
+    }
+
+    static async Task HandleForward(TcpClient remote)
+    {
+        string token = "secret";
+        if (!agents.TryGetValue(token, out var agent))
+        {
+            remote.Close();
+            return;
+        }
+        var id = Guid.NewGuid().ToString();
+        agent.ForwardConnections[id] = remote;
+        await agent.SendAsync(new { Type = "PortOpen", Id = id, Port = 22 });
+        _ = PumpRemoteToAgent(agent, id, remote);
+    }
+
+    static async Task PumpRemoteToAgent(AgentConnection agent, string id, TcpClient remote)
+    {
+        var stream = remote.GetStream();
+        var buf = new byte[4096];
+        try
+        {
+            while (true)
+            {
+                int n = await stream.ReadAsync(buf, 0, buf.Length);
+                if (n <= 0) break;
+                await agent.SendAsync(new { Type = "PortData", Id = id, Data = Convert.ToBase64String(buf, 0, n) });
+            }
+        }
+        finally
+        {
+            await agent.SendAsync(new { Type = "PortClose", Id = id });
+            remote.Close();
+        }
+    }
+}
+
+record HttpResponse(int StatusCode, Dictionary<string, string> Headers, string Body);
+
+class AgentConnection
+{
+    public string Token { get; }
+    public TcpClient Client { get; }
+    readonly StreamReader reader;
+    readonly StreamWriter writer;
+    public ConcurrentDictionary<string, TaskCompletionSource<HttpResponse>> Pending { get; } = new();
+    public ConcurrentDictionary<string, TcpClient> ForwardConnections { get; } = new();
+
+    public AgentConnection(string token, TcpClient client, StreamReader r, StreamWriter w)
+    {
+        Token = token;
+        Client = client;
+        reader = r;
+        writer = w;
+    }
+
+    public Task SendAsync(object obj)
+    {
+        string json = JsonSerializer.Serialize(obj);
+        return writer.WriteLineAsync(json);
+    }
+
+    public async Task ProcessMessages()
+    {
+        string? line;
+        while ((line = await reader.ReadLineAsync()) != null)
+        {
+            var doc = JsonDocument.Parse(line);
+            var type = doc.RootElement.GetProperty("Type").GetString();
+            var id = doc.RootElement.GetProperty("Id").GetString()!;
+            if (type == "HttpResponse")
+            {
+                var resp = new HttpResponse(
+                    doc.RootElement.GetProperty("StatusCode").GetInt32(),
+                    doc.RootElement.GetProperty("Headers").EnumerateObject().ToDictionary(p => p.Name, p => p.Value.GetString()!),
+                    Encoding.UTF8.GetString(Convert.FromBase64String(doc.RootElement.GetProperty("Body").GetString() ?? ""))
+                );
+                if (Pending.TryRemove(id, out var tcs)) tcs.SetResult(resp);
+            }
+            else if (type == "PortData")
+            {
+                if (ForwardConnections.TryGetValue(id, out var conn))
+                {
+                    var data = Convert.FromBase64String(doc.RootElement.GetProperty("Data").GetString()!);
+                    await conn.GetStream().WriteAsync(data, 0, data.Length);
+                }
+            }
+            else if (type == "PortClose")
+            {
+                if (ForwardConnections.TryRemove(id, out var conn))
+                {
+                    conn.Close();
+                }
+            }
+        }
+    }
+}

--- a/csharp-proxy/Server/Server.csproj
+++ b/csharp-proxy/Server/Server.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add `csharp-proxy` prototype showing agent/server split in C#
- server forwards authenticated HTTP requests and exposes SSH port forwarding
- agent relays HTTP and TCP traffic back to the target machine

## Testing
- `go test ./...` *(fails: failed to retrieve response > Post "https://1.1.1.1/dns-query": dial tcp 1.1.1.1:443: connect: network is unreachable)*
- `apt-get update` *(fails: repository InRelease is not signed)*
- `dotnet build csharp-proxy/Server/Server.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_6893b69936e48324acebe695d1a2a560