### PR TITLE
Add WebSocket-based C# proxy with TLS and port management

### DIFF
--- a/csharp-proxy/Agent/Agent.csproj
+++ b/csharp-proxy/Agent/Agent.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+</Project>

--- a/csharp-proxy/Agent/Config.cs
+++ b/csharp-proxy/Agent/Config.cs
@@ -1,0 +1,7 @@
+public static class AgentConfig
+{
+    public const string ServerUrl = "wss://localhost:9001"; // server address
+    public const string Token = "secret"; // authentication token
+    public const string ClientId = "agent-1"; // unique client id, e.g., MAC address
+    public const bool ValidateServerCertificate = false; // set true to validate TLS cert
+}

--- a/csharp-proxy/Agent/Program.cs
+++ b/csharp-proxy/Agent/Program.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        using var ws = new ClientWebSocket();
+        ws.Options.KeepAliveInterval = TimeSpan.FromSeconds(30);
+        if (!AgentConfig.ValidateServerCertificate)
+        {
+            ws.Options.RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => true;
+        }
+        var uri = new Uri($"{AgentConfig.ServerUrl}/tunnel?token={AgentConfig.Token}&id={AgentConfig.ClientId}");
+        await ws.ConnectAsync(uri, CancellationToken.None);
+        var agent = new Agent(ws);
+        await agent.Run();
+    }
+}
+
+class Agent
+{
+    readonly ClientWebSocket ws;
+    readonly HttpClient http = new HttpClient();
+    readonly ConcurrentDictionary<string, TcpClient> forwards = new();
+
+    public Agent(ClientWebSocket socket)
+    {
+        ws = socket;
+    }
+
+    public async Task Run()
+    {
+        await SendTextAsync(new { Type = "PortRequest", Id = AgentConfig.ClientId });
+        var buffer = new byte[8192];
+        while (ws.State == WebSocketState.Open)
+        {
+            var result = await ws.ReceiveAsync(buffer, CancellationToken.None);
+            if (result.MessageType == WebSocketMessageType.Close) break;
+            if (result.MessageType == WebSocketMessageType.Text)
+            {
+                var json = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                var doc = JsonDocument.Parse(json);
+                var type = doc.RootElement.GetProperty("Type").GetString();
+                var id = doc.RootElement.GetProperty("Id").GetString()!;
+                if (type == "HttpRequest")
+                {
+                    var method = doc.RootElement.GetProperty("Method").GetString()!;
+                    var url = doc.RootElement.GetProperty("Url").GetString()!;
+                    var headers = doc.RootElement.GetProperty("Headers").EnumerateObject().ToDictionary(p => p.Name, p => p.Value.GetString()!);
+                    var bodyBytes = doc.RootElement.GetProperty("Body").GetBytesFromBase64();
+                    var req = new HttpRequestMessage(new HttpMethod(method), url);
+                    foreach (var h in headers)
+                        req.Headers.TryAddWithoutValidation(h.Key, h.Value);
+                    if (bodyBytes.Length > 0)
+                        req.Content = new ByteArrayContent(bodyBytes);
+                    var resp = await http.SendAsync(req);
+                    var respHeaders = resp.Headers.Concat(resp.Content.Headers)
+                        .ToDictionary(h => h.Key, h => string.Join(",", h.Value));
+                    var respBody = await resp.Content.ReadAsByteArrayAsync();
+                    await SendTextAsync(new
+                    {
+                        Type = "HttpResponse",
+                        Id = id,
+                        StatusCode = (int)resp.StatusCode,
+                        Headers = respHeaders,
+                        Body = Convert.ToBase64String(respBody)
+                    });
+                }
+                else if (type == "PortAssigned")
+                {
+                    // server replied with assigned public port, nothing to do client-side
+                }
+                else if (type == "PortOpen")
+                {
+                    int port = doc.RootElement.GetProperty("Port").GetInt32();
+                    var local = new TcpClient();
+                    await local.ConnectAsync("127.0.0.1", port);
+                    forwards[id] = local;
+                    _ = PumpLocalToServer(id, local);
+                }
+                else if (type == "PortClose")
+                {
+                    if (forwards.TryRemove(id, out var local))
+                    {
+                        local.Close();
+                    }
+                }
+            }
+            else if (result.MessageType == WebSocketMessageType.Binary)
+            {
+                var id = Encoding.ASCII.GetString(buffer, 0, 36);
+                if (forwards.TryGetValue(id, out var local))
+                {
+                    await local.GetStream().WriteAsync(buffer.AsMemory(36, result.Count - 36));
+                }
+            }
+        }
+    }
+
+    async Task PumpLocalToServer(string id, TcpClient local)
+    {
+        var stream = local.GetStream();
+        var buf = ArrayPool<byte>.Shared.Rent(4096 + 36);
+        try
+        {
+            Encoding.ASCII.GetBytes(id, 0, id.Length, buf, 0);
+            while (true)
+            {
+                int n = await stream.ReadAsync(buf, 36, buf.Length - 36);
+                if (n <= 0) break;
+                await ws.SendAsync(buf.AsMemory(0, n + 36), WebSocketMessageType.Binary, true, CancellationToken.None);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buf);
+            await SendTextAsync(new { Type = "PortClose", Id = id });
+            local.Close();
+        }
+    }
+
+    Task SendTextAsync(object obj)
+    {
+        var json = JsonSerializer.Serialize(obj);
+        var bytes = Encoding.UTF8.GetBytes(json);
+        return ws.SendAsync(bytes, WebSocketMessageType.Text, true, CancellationToken.None);
+    }
+}

--- a/csharp-proxy/README.md
+++ b/csharp-proxy/README.md
@@ -1,0 +1,34 @@
+# C# Reverse Proxy
+
+This prototype demonstrates a minimal reverse proxy and port forwarding system inspired by the v2ray-core architecture.
+
+* **Agent (A)** – runs inside the private network and keeps a persistent WebSocket (wss) connection to the server, using ping/pong as heartbeat.
+* **Server (S)** – accepts the agent connection and exposes:
+  * an HTTPS endpoint for authenticated clients to issue arbitrary HTTP requests through the agent;
+  * dynamic TCP port forwarding (similar to frp) allowing remote SSH access. Ports are assigned per-agent and recorded in SQLite.
+
+Binary WebSocket frames carry raw TCP data without base64 overhead. Control messages and HTTP payloads use JSON text frames.
+
+### Building
+A .NET SDK is required:
+```bash
+dotnet build
+```
+
+### Running
+1. Start the server:
+```bash
+dotnet run --project Server/Server.csproj
+```
+2. Start the agent on the machine that owns the network connection:
+```bash
+dotnet run --project Agent/Agent.csproj
+```
+3. Issue HTTP requests through the server:
+   ```bash
+curl -H 'X-Forward-Token: secret' -H 'X-Target-Url: http://example.com' \
+       -H 'X-Forward-Method: GET' https://<server_host>:9001/http
+```
+4. On first connection the agent requests a public port; check `https://<server_host>:9001/admin` for the assigned value and connect to that port to reach the agent's local port `22`.
+
+This is a simplified educational example and lacks production-ready security and error handling.

--- a/csharp-proxy/Server/Config.cs
+++ b/csharp-proxy/Server/Config.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+public static class ServerConfig
+{
+    public const int WebSocketPort = 9001; // wss port
+    public const string Token = "secret"; // shared token
+    public const string CertPath = "server.pfx"; // TLS certificate (PFX)
+    public const string CertPassword = "password"; // TLS certificate password
+    public const string AdminUser = "admin";
+    public const string AdminPass = "adminpass";
+    public static readonly HashSet<int> ReservedPorts = new() { WebSocketPort }; // ports that cannot be used
+    public const int PortRangeStart = 20000;
+    public const int PortRangeEnd = 21000;
+}

--- a/csharp-proxy/Server/PortMap.cs
+++ b/csharp-proxy/Server/PortMap.cs
@@ -1,0 +1,76 @@
+using Microsoft.Data.Sqlite;
+using System.Collections.Generic;
+using System.IO;
+
+public class PortMap
+{
+    readonly string _dbPath = Path.Combine(AppContext.BaseDirectory, "portmap.db");
+
+    public PortMap()
+    {
+        using var conn = new SqliteConnection($"Data Source={_dbPath}");
+        conn.Open();
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = "CREATE TABLE IF NOT EXISTS mappings (clientId TEXT PRIMARY KEY, port INTEGER);" +
+                          "CREATE TABLE IF NOT EXISTS reserved (port INTEGER PRIMARY KEY);";
+        cmd.ExecuteNonQuery();
+    }
+
+    public int GetOrAssignPort(string clientId)
+    {
+        using var conn = new SqliteConnection($"Data Source={_dbPath}");
+        conn.Open();
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT port FROM mappings WHERE clientId=$id";
+        cmd.Parameters.AddWithValue("$id", clientId);
+        var portObj = cmd.ExecuteScalar();
+        if (portObj != null && portObj is long p)
+            return (int)p;
+
+        int port = FindFreePort(conn);
+        cmd = conn.CreateCommand();
+        cmd.CommandText = "INSERT INTO mappings(clientId, port) VALUES($id,$p)";
+        cmd.Parameters.AddWithValue("$id", clientId);
+        cmd.Parameters.AddWithValue("$p", port);
+        cmd.ExecuteNonQuery();
+        return port;
+    }
+
+    int FindFreePort(SqliteConnection conn)
+    {
+        for (int p = ServerConfig.PortRangeStart; p <= ServerConfig.PortRangeEnd; p++)
+        {
+            if (ServerConfig.ReservedPorts.Contains(p)) continue;
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT 1 FROM mappings WHERE port=$p UNION SELECT 1 FROM reserved WHERE port=$p";
+            cmd.Parameters.AddWithValue("$p", p);
+            if (cmd.ExecuteScalar() == null)
+                return p;
+        }
+        throw new Exception("no free port");
+    }
+
+    public IEnumerable<(string ClientId, int Port)> ListMappings()
+    {
+        using var conn = new SqliteConnection($"Data Source={_dbPath}");
+        conn.Open();
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT clientId, port FROM mappings";
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            yield return (reader.GetString(0), reader.GetInt32(1));
+        }
+    }
+
+    public void AddReserved(int port)
+    {
+        ServerConfig.ReservedPorts.Add(port);
+        using var conn = new SqliteConnection($"Data Source={_dbPath}");
+        conn.Open();
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = "INSERT OR IGNORE INTO reserved(port) VALUES($p)";
+        cmd.Parameters.AddWithValue("$p", port);
+        cmd.ExecuteNonQuery();
+    }
+}

--- a/csharp-proxy/Server/Program.cs
+++ b/csharp-proxy/Server/Program.cs
@@ -1,0 +1,223 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.UseKestrel(options =>
+{
+    options.ListenAnyIP(ServerConfig.WebSocketPort, listen => listen.UseHttps(ServerConfig.CertPath, ServerConfig.CertPassword));
+});
+builder.Services.AddSingleton<PortMap>();
+var app = builder.Build();
+
+app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(30) });
+ConcurrentDictionary<string, AgentConnection> agents = new();
+
+// WebSocket tunnel for agents
+app.Map("/tunnel", async (HttpContext ctx, PortMap portMap) =>
+{
+    if (!ctx.WebSockets.IsWebSocketRequest)
+    {
+        ctx.Response.StatusCode = 400;
+        return;
+    }
+    var token = ctx.Request.Query["token"].ToString();
+    if (token != ServerConfig.Token)
+    {
+        ctx.Response.StatusCode = 401;
+        return;
+    }
+    var id = ctx.Request.Query["id"].ToString();
+    var ws = await ctx.WebSockets.AcceptWebSocketAsync();
+    var agent = new AgentConnection(id, ws, portMap);
+    agents[id] = agent;
+    await agent.RunAsync();
+    agents.TryRemove(id, out _);
+});
+
+// HTTP forward endpoint
+app.Map("/http", async (HttpContext ctx) =>
+{
+    var token = ctx.Request.Headers["X-Forward-Token"].ToString();
+    var target = ctx.Request.Headers["X-Target-Url"].ToString();
+    var method = ctx.Request.Headers["X-Forward-Method"].ToString();
+    if (string.IsNullOrEmpty(method)) method = ctx.Request.Method;
+    if (!agents.TryGetValue(token, out var agent) || string.IsNullOrEmpty(target))
+    {
+        ctx.Response.StatusCode = 502;
+        return;
+    }
+    using var reader = new StreamReader(ctx.Request.Body);
+    var body = await reader.ReadToEndAsync();
+    var headers = ctx.Request.Headers.ToDictionary(h => h.Key, h => h.Value.ToString());
+    var resp = await agent.SendHttpAsync(method, target, headers, Encoding.UTF8.GetBytes(body));
+    ctx.Response.StatusCode = resp.StatusCode;
+    foreach (var h in resp.Headers)
+        ctx.Response.Headers[h.Key] = h.Value;
+    await ctx.Response.Body.WriteAsync(resp.Body, 0, resp.Body.Length);
+});
+
+// Admin page listing online agents and ports
+app.Map("/admin", async (HttpContext ctx, PortMap portMap) =>
+{
+    if (!Authenticate(ctx)) return;
+    var sb = new StringBuilder();
+    sb.Append("<html><body><h3>Mappings</h3><ul>");
+    foreach (var (cid, port) in portMap.ListMappings())
+        sb.Append($"<li>{WebUtility.HtmlEncode(cid)} -> {port}</li>");
+    sb.Append("</ul></body></html>");
+    ctx.Response.ContentType = "text/html";
+    await ctx.Response.WriteAsync(sb.ToString());
+});
+
+// Reserve a port via admin
+app.MapPost("/admin/reserve/{port:int}", (int port, HttpContext ctx, PortMap portMap) =>
+{
+    if (!Authenticate(ctx)) return Results.Unauthorized();
+    portMap.AddReserved(port);
+    return Results.Ok();
+});
+
+bool Authenticate(HttpContext ctx)
+{
+    string? auth = ctx.Request.Headers["Authorization"];
+    if (auth == null || !auth.StartsWith("Basic "))
+    {
+        ctx.Response.Headers["WWW-Authenticate"] = "Basic";
+        ctx.Response.StatusCode = 401;
+        return false;
+    }
+    var pair = Encoding.UTF8.GetString(Convert.FromBase64String(auth[6..])).Split(':');
+    if (pair.Length != 2 || pair[0] != ServerConfig.AdminUser || pair[1] != ServerConfig.AdminPass)
+    {
+        ctx.Response.StatusCode = 401;
+        return false;
+    }
+    return true;
+}
+
+app.Run();
+
+// === supporting types ===
+record HttpResp(int StatusCode, Dictionary<string, string> Headers, byte[] Body);
+
+class AgentConnection
+{
+    readonly string id;
+    readonly WebSocket ws;
+    readonly PortMap portMap;
+    readonly ConcurrentDictionary<string, TaskCompletionSource<HttpResp>> pending = new();
+    readonly ConcurrentDictionary<string, TcpClient> forwards = new();
+
+    public AgentConnection(string id, WebSocket ws, PortMap map)
+    {
+        this.id = id;
+        this.ws = ws;
+        portMap = map;
+    }
+
+    public async Task RunAsync()
+    {
+        var buffer = new byte[8192];
+        while (ws.State == WebSocketState.Open)
+        {
+            var result = await ws.ReceiveAsync(buffer, CancellationToken.None);
+            if (result.MessageType == WebSocketMessageType.Close) break;
+            if (result.MessageType == WebSocketMessageType.Text)
+            {
+                var json = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                var doc = JsonDocument.Parse(json);
+                var type = doc.RootElement.GetProperty("Type").GetString();
+                var mid = doc.RootElement.GetProperty("Id").GetString()!;
+                if (type == "HttpResponse")
+                {
+                    var resp = new HttpResp(
+                        doc.RootElement.GetProperty("StatusCode").GetInt32(),
+                        doc.RootElement.GetProperty("Headers").EnumerateObject().ToDictionary(p => p.Name, p => p.Value.GetString()!),
+                        doc.RootElement.GetProperty("Body").GetBytesFromBase64());
+                    if (pending.TryRemove(mid, out var tcs)) tcs.SetResult(resp);
+                }
+                else if (type == "PortRequest")
+                {
+                    int port = portMap.GetOrAssignPort(mid);
+                    _ = StartPortListener(port);
+                    await SendTextAsync(new { Type = "PortAssigned", Id = mid, Port = port });
+                }
+                else if (type == "PortClose")
+                {
+                    if (forwards.TryRemove(mid, out var c)) c.Close();
+                }
+            }
+            else if (result.MessageType == WebSocketMessageType.Binary)
+            {
+                var mid = Encoding.ASCII.GetString(buffer, 0, 36);
+                if (forwards.TryGetValue(mid, out var c))
+                {
+                    await c.GetStream().WriteAsync(buffer.AsMemory(36, result.Count - 36));
+                }
+            }
+        }
+    }
+
+    public async Task<HttpResp> SendHttpAsync(string method, string url, Dictionary<string, string> headers, byte[] body)
+    {
+        var id = Guid.NewGuid().ToString();
+        var tcs = new TaskCompletionSource<HttpResp>();
+        pending[id] = tcs;
+        await SendTextAsync(new
+        {
+            Type = "HttpRequest",
+            Id = id,
+            Method = method,
+            Url = url,
+            Headers = headers,
+            Body = Convert.ToBase64String(body)
+        });
+        return await tcs.Task;
+    }
+
+    async Task StartPortListener(int port)
+    {
+        var listener = new TcpListener(IPAddress.Any, port);
+        listener.Start();
+        while (ws.State == WebSocketState.Open)
+        {
+            var remote = await listener.AcceptTcpClientAsync();
+            var id = Guid.NewGuid().ToString();
+            forwards[id] = remote;
+            await SendTextAsync(new { Type = "PortOpen", Id = id, Port = 22 });
+            _ = PumpRemoteToAgent(id, remote);
+        }
+    }
+
+    async Task PumpRemoteToAgent(string id, TcpClient remote)
+    {
+        var stream = remote.GetStream();
+        var buf = new byte[4096 + 36];
+        Encoding.ASCII.GetBytes(id, 0, id.Length, buf, 0);
+        try
+        {
+            while (true)
+            {
+                int n = await stream.ReadAsync(buf, 36, buf.Length - 36);
+                if (n <= 0) break;
+                await ws.SendAsync(buf.AsMemory(0, n + 36), WebSocketMessageType.Binary, true, CancellationToken.None);
+            }
+        }
+        finally
+        {
+            await SendTextAsync(new { Type = "PortClose", Id = id });
+            remote.Close();
+            forwards.TryRemove(id, out _);
+        }
+    }
+
+    Task SendTextAsync(object obj)
+    {
+        var json = JsonSerializer.Serialize(obj);
+        var bytes = Encoding.UTF8.GetBytes(json);
+        return ws.SendAsync(bytes, WebSocketMessageType.Text, true, CancellationToken.None);
+    }
+}

--- a/csharp-proxy/Server/Server.csproj
+++ b/csharp-proxy/Server/Server.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- move agent and server prototype to WebSocket (wss) with ping/pong keepalive and binary frames
- add compile-time configs and TLS setup plus SQLite-backed port reservation with a basic admin page
- implement per-client port allocation and raw TCP forwarding without base64 overhead

## Testing
- `go test ./...` *(fails: FAIL)*
- `dotnet build csharp-proxy/Server/Server.csproj` *(fails: command not found: dotnet)*
- `dotnet build csharp-proxy/Agent/Agent.csproj` *(fails: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_6893b69936e48324acebe695d1a2a560